### PR TITLE
Changing filed_licence to field_license

### DIFF
--- a/dkan_nkod.features.field_base.inc
+++ b/dkan_nkod.features.field_base.inc
@@ -73,13 +73,13 @@ function dkan_nkod_field_default_field_bases() {
     'type' => 'text',
   );
 
-  // Exported field_base: 'field_licence'.
-  $field_bases['field_licence'] = array(
+  // Exported field_base: 'field_license'.
+  $field_bases['field_license'] = array(
     'active' => 1,
     'cardinality' => 1,
     'deleted' => 0,
     'entity_types' => array(),
-    'field_name' => 'field_licence',
+    'field_name' => 'field_license',
     'indexes' => array(
       'format' => array(
         0 => 'format',


### PR DESCRIPTION
Module cant be used without aditional changes to fileds, because in default package_show api, as defined in dkan_nkod.features.inc, the value for license link is set to [node:field-resources:Nth:field-license], but field in content type resource, as defined here, in dkan_nkod.features.field_instance.inc and dkan_nkod.info, has machine name "field_licence". So there is need for "unification".
Decided to change it here (and the other two files) in order to be consitent with the english (us) naming of machine names of fields.
