### PR TITLE
Changing filed_licence to field_license

### DIFF
--- a/dkan_nkod.features.field_instance.inc
+++ b/dkan_nkod.features.field_instance.inc
@@ -614,8 +614,8 @@ function dkan_nkod_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-resource-field_licence'.
-  $field_instances['node-resource-field_licence'] = array(
+  // Exported field_instance: 'node-resource-field_license'.
+  $field_instances['node-resource-field_license'] = array(
     'bundle' => 'resource',
     'default_value' => NULL,
     'deleted' => 0,
@@ -642,7 +642,7 @@ function dkan_nkod_field_default_field_instances() {
       ),
     ),
     'entity_type' => 'node',
-    'field_name' => 'field_licence',
+    'field_name' => 'field_license',
     'label' => 'Odkaz na podmínky užití',
     'required' => 1,
     'settings' => array(


### PR DESCRIPTION
Module cant be used without aditional changes to fileds, because in default package_show api, as defined in dkan_nkod.features.inc, the value for license link is set to [node:field-resources:Nth:field-license], but field in content type resource, as defined here, in dkan_nkod.features.field_base.inc and dkan_nkod.info, has machine name "field_licence". So there is need for "unification".
Decided to change it here (and the other two files) in order to be consitent with the english (us) naming of machine names of fields.
